### PR TITLE
Fix for vanity url not working

### DIFF
--- a/.github/workflows/connect-publish.yaml
+++ b/.github/workflows/connect-publish.yaml
@@ -13,7 +13,7 @@ jobs:
   connect-publish:
     runs-on: ubuntu-latest
     env:
-      APP_NAME: uace-needs-assessment #edit this to change the custom URL of the app
+      APP_NAME: uace-eric #edit this to change the custom URL of the app
       APP_DIR: dashboard #edit this if you rename or move the contents of the app
       APP_ACCESS: all #See https://github.com/rstudio/actions/tree/main/connect-publish#access-type
     steps:
@@ -43,4 +43,7 @@ jobs:
           access-type: ${{ env.APP_ACCESS }}
           dir: |
             ./${{ env.APP_DIR }}/:${{ env.APP_NAME }}
+          require-vanity-path: true
+          show-logs: true
+          
             

--- a/.github/workflows/connect-publish.yaml
+++ b/.github/workflows/connect-publish.yaml
@@ -13,7 +13,7 @@ jobs:
   connect-publish:
     runs-on: ubuntu-latest
     env:
-      APP_NAME: uace-eric #edit this to change the custom URL of the app
+      APP_NAME: uace-needs-assessment #edit this to change the custom URL of the app
       APP_DIR: dashboard #edit this if you rename or move the contents of the app
       APP_ACCESS: all #See https://github.com/rstudio/actions/tree/main/connect-publish#access-type
     steps:


### PR DESCRIPTION
I _think_ this should fix the issue with viz.datascience.arizona.edu/uace-needs-assessment not pointing to the app.  I've made sure to delete the app I published at that URL, but it's possible that this will error when it's merged if it thinks the name "uace-needs-assessment" is already taken.  If it does, you _should_ be able to just change the app name.